### PR TITLE
fix: spotless 와 충돌하는 naver-checkstyle 수정

### DIFF
--- a/backend/back/config/checkstyle/checkstyle.xml
+++ b/backend/back/config/checkstyle/checkstyle.xml
@@ -229,34 +229,34 @@ The following rules in the Naver coding convention cannot be checked by this con
 
         <!-- [block-indentation][indentation-after-line-wrapping] -->
         <!-- checkstyle 6.16 이상을 써야지 탭을 쓸때의 인덴트 체크가 제대로 동작함 -->
-        <module name="Indentation">
-            <property name="basicOffset" value="4"/>
-            <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="4"/>
-            <property name="throwsIndent" value="4"/>
-            <property name="lineWrappingIndentation" value="4"/>
-            <property name="arrayInitIndent" value="4"/>
-        </module>
+<!--        <module name="Indentation">-->
+<!--            <property name="basicOffset" value="4"/>-->
+<!--            <property name="braceAdjustment" value="0"/>-->
+<!--            <property name="caseIndent" value="4"/>-->
+<!--            <property name="throwsIndent" value="4"/>-->
+<!--            <property name="lineWrappingIndentation" value="4"/>-->
+<!--            <property name="arrayInitIndent" value="4"/>-->
+<!--        </module>-->
 
         <!-- [line-wrapping-position] -->
-        <module name="SeparatorWrap">
-            <property name="tokens" value="COMMA"/>
-            <property name="option" value="EOL"/>
-            <message key="line.previous"
-                     value="[line-wrapping-position] ''{0}'' should be on the previous line."/>
-        </module>
-        <module name="SeparatorWrap">
-            <property name="tokens" value="DOT"/>
-            <property name="option" value="NL"/>
-            <message key="line.new"
-                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
-        </module>
-        <module name="OperatorWrap">
-            <property name="option" value="NL"/>
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
-            <message key="line.new"
-                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
-        </module>
+<!--        <module name="SeparatorWrap">-->
+<!--            <property name="tokens" value="COMMA"/>-->
+<!--            <property name="option" value="EOL"/>-->
+<!--            <message key="line.previous"-->
+<!--                     value="[line-wrapping-position] ''{0}'' should be on the previous line."/>-->
+<!--        </module>-->
+<!--        <module name="SeparatorWrap">-->
+<!--            <property name="tokens" value="DOT"/>-->
+<!--            <property name="option" value="NL"/>-->
+<!--            <message key="line.new"-->
+<!--                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>-->
+<!--        </module>-->
+<!--        <module name="OperatorWrap">-->
+<!--            <property name="option" value="NL"/>-->
+<!--            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>-->
+<!--            <message key="line.new"-->
+<!--                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>-->
+<!--        </module>-->
 
         <!-- End of Line-wrapping chapter -->
 
@@ -275,19 +275,19 @@ The following rules in the Naver coding convention cannot be checked by this con
         -->
 
         <!-- [import-grouping] -->
-        <module name="ImportOrder">
-            <property name="groups" value="java., javax., org., net., /com\.(?!nhncorp|navercorp|naver)/, /(?!java\.|javax\.|com\.|org\.|net\.)/, com.nhncorp., com.navercorp., com.naver."/>
-            <property name="ordered" value="true"/>
-            <property name="separated" value="true"/>
-            <property name="option" value="top"/>
-            <property name="sortStaticImportsAlphabetically" value="true"/>
-            <message key="import.groups.separated.internally"
-                     value="[import-grouping] Extra separation in import group before ''{0}''"/>
-            <message key="import.ordering"
-                     value="[import-grouping] Wrong order for ''{0}'' import."/>
-            <message key="import.separation"
-                     value="[import-grouping] ''{0}'' should be separated from previous imports."/>
-        </module>
+<!--        <module name="ImportOrder">-->
+<!--            <property name="groups" value="java., javax., org., net., /com\.(?!nhncorp|navercorp|naver)/, /(?!java\.|javax\.|com\.|org\.|net\.)/, com.nhncorp., com.navercorp., com.naver."/>-->
+<!--            <property name="ordered" value="true"/>-->
+<!--            <property name="separated" value="true"/>-->
+<!--            <property name="option" value="top"/>-->
+<!--            <property name="sortStaticImportsAlphabetically" value="true"/>-->
+<!--            <message key="import.groups.separated.internally"-->
+<!--                     value="[import-grouping] Extra separation in import group before ''{0}''"/>-->
+<!--            <message key="import.ordering"-->
+<!--                     value="[import-grouping] Wrong order for ''{0}'' import."/>-->
+<!--            <message key="import.separation"-->
+<!--                     value="[import-grouping] ''{0}'' should be separated from previous imports."/>-->
+<!--        </module>-->
 
         <!-- [blankline-between-methods] -->
         <module name="EmptyLineSeparator">
@@ -301,16 +301,16 @@ The following rules in the Naver coding convention cannot be checked by this con
         <!-- Start of Whitespace chapter -->
 
         <!-- [space-around-brace] -->
-        <module name="WhitespaceAround">
-            <property name="allowEmptyConstructors" value="true"/> <!-- [permit-concise-empty-block] -->
-            <property name="allowEmptyMethods" value="true"/>  <!-- [permit-concise-empty-block] -->
-            <property name="allowEmptyLoops" value="true"/>  <!-- [permit-concise-empty-block] -->
-            <property name="tokens" value="LCURLY, RCURLY, SLIST"/>
-            <message key="ws.notFollowed"
-                     value="[space-around-brace] ''{0}'' is not followed by whitespace."/>
-            <message key="ws.notPreceded"
-                     value="[space-around-brace] ''{0}'' is not preceded with whitespace."/>
-        </module>
+<!--        <module name="WhitespaceAround">-->
+<!--            <property name="allowEmptyConstructors" value="true"/> &lt;!&ndash; [permit-concise-empty-block] &ndash;&gt;-->
+<!--            <property name="allowEmptyMethods" value="true"/>  &lt;!&ndash; [permit-concise-empty-block] &ndash;&gt;-->
+<!--            <property name="allowEmptyLoops" value="true"/>  &lt;!&ndash; [permit-concise-empty-block] &ndash;&gt;-->
+<!--            <property name="tokens" value="LCURLY, RCURLY, SLIST"/>-->
+<!--            <message key="ws.notFollowed"-->
+<!--                     value="[space-around-brace] ''{0}'' is not followed by whitespace."/>-->
+<!--            <message key="ws.notPreceded"-->
+<!--                     value="[space-around-brace] ''{0}'' is not preceded with whitespace."/>-->
+<!--        </module>-->
 
         <!-- [space-between-keyword-parentheses] -->
         <module name="WhitespaceAround">


### PR DESCRIPTION


## 🔗 Issue 번호

- Close #22 

## 🛠 작업 내역

whitespaceAround 주석처리
indentation 주석처리.
importOrder 주석처리,
Operator Wrap,SeparatorWrap 주석처리

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?