### PR TITLE
FEAT: 노무사 정보 크롤링 기능

### DIFF
--- a/backend/back/build.gradle.kts
+++ b/backend/back/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0")
+    implementation("org.jsoup:jsoup:1.17.2") // 웹 크롤링을 위해 Jsoup 라이브러리 추가
 }
 
 tasks.withType<Test> {

--- a/backend/back/src/main/java/com/back/domain/welfare/center/entity/Lawyer.java
+++ b/backend/back/src/main/java/com/back/domain/welfare/center/entity/Lawyer.java
@@ -1,20 +1,31 @@
 package com.back.domain.welfare.center.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
-@Table(name = "lawyer")
+@Table(
+        name = "lawyer",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_lawyer_name_corp",
+                    columnNames = {"name", "corporation"})
+        }) // name + corporation 로 같은 노무사인지 판단 -> 중복 방지
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lawyer {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String name;
-    private String district;
+
+    @Column(nullable = false)
     private String corporation;
+
+    private String district;
 }

--- a/backend/back/src/main/java/com/back/domain/welfare/center/repository/LawyerRepository.java
+++ b/backend/back/src/main/java/com/back/domain/welfare/center/repository/LawyerRepository.java
@@ -1,0 +1,9 @@
+package com.back.domain.welfare.center.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.welfare.center.entity.Lawyer;
+
+public interface LawyerRepository extends JpaRepository<Lawyer, Long> {
+    boolean existsByNameAndCorporation(String name, String corporation);
+}

--- a/backend/back/src/main/java/com/back/domain/welfare/center/service/LawyerCrawlerService.java
+++ b/backend/back/src/main/java/com/back/domain/welfare/center/service/LawyerCrawlerService.java
@@ -1,0 +1,82 @@
+package com.back.domain.welfare.center.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import com.back.domain.welfare.center.entity.Lawyer;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LawyerCrawlerService {
+    private final String BASE_URL = "https://www.youthlabor.co.kr/company/search?area=&area2=&text=&page=";
+    private static final int BATCH_SIZE = 100;
+    private final LawyerSaveService lawyerSaveService;
+
+    public void crawlMultiPages(int startPage, int endPage) {
+        List<Lawyer> lawyerList = new ArrayList<>();
+
+        for (int i = startPage; i <= endPage; i++) {
+            String url = BASE_URL + i;
+            Elements rows = crawlAndSelectRows(url);
+            // 테이블 내부 각각 행의 정보을 받아옴
+
+            for (Element row : rows) {
+                // 받아온 행들을 순회, td에서 데이터 추출
+                Elements cols = row.select("td");
+
+                // 데이터가 3개 다 있는 행인지 확인하고 출력
+                if (cols.size() >= 3) {
+                    String region = cols.get(0).text();
+                    String name = cols.get(1).text();
+                    String company = cols.get(2).text();
+
+                    Lawyer lawyer = Lawyer.builder()
+                            .district(region)
+                            .name(name)
+                            .corporation(company)
+                            .build();
+
+                    lawyerList.add(lawyer);
+                }
+                // 100건마다 즉시 저장
+                if (lawyerList.size() >= BATCH_SIZE) {
+                    lawyerSaveService.saveList(lawyerList);
+                    lawyerList.clear();
+                }
+            }
+            try {
+                Thread.sleep(300);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        // 마지막 남은 데이터 저장
+        if (!lawyerList.isEmpty()) {
+            lawyerSaveService.saveList(lawyerList);
+            lawyerList.clear();
+        }
+    }
+
+    public Elements crawlAndSelectRows(String url) {
+        try {
+            Document doc =
+                    Jsoup.connect(url).userAgent("Mozilla/5.0").timeout(10000).get();
+            return doc.select("table tbody tr");
+            // table의 -> tbody -> tr 조회
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+            // 에러 발생 시 프로그램이 멈추지 않도록, 빈 Elements 반환
+            return new Elements();
+        }
+    }
+}

--- a/backend/back/src/main/java/com/back/domain/welfare/center/service/LawyerSaveService.java
+++ b/backend/back/src/main/java/com/back/domain/welfare/center/service/LawyerSaveService.java
@@ -1,0 +1,28 @@
+package com.back.domain.welfare.center.service;
+
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.welfare.center.entity.Lawyer;
+import com.back.domain.welfare.center.repository.LawyerRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LawyerSaveService {
+    private final LawyerRepository lawyerRepository;
+
+    @Transactional
+    public void saveList(List<Lawyer> lawyerList) {
+        for (Lawyer lawyer : lawyerList) {
+            try {
+                lawyerRepository.save(lawyer);
+            } catch (DataIntegrityViolationException e) {
+            }
+        }
+    }
+}

--- a/backend/back/src/test/java/com/back/domain/welfare/center/service/LawyerCrawlerServiceTest.java
+++ b/backend/back/src/test/java/com/back/domain/welfare/center/service/LawyerCrawlerServiceTest.java
@@ -1,0 +1,57 @@
+package com.back.domain.welfare.center.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.welfare.center.entity.Lawyer;
+import com.back.domain.welfare.center.repository.LawyerRepository;
+
+@SpringBootTest
+@Transactional
+class LawyerCrawlerTest {
+    @Autowired
+    private LawyerCrawlerService lawyerCrawlerService;
+
+    @Autowired
+    private LawyerRepository lawyerRepository;
+
+    @Test
+    @DisplayName("1,2페이지 크롤링 테스트")
+    void t1() throws Exception {
+        long count = lawyerRepository.count();
+
+        lawyerCrawlerService.crawlMultiPages(1, 2);
+
+        List<Lawyer> savedLawyers = lawyerRepository.findAll();
+        assertThat(savedLawyers.size()).isGreaterThan((int) count);
+
+        Lawyer firstLawyer = savedLawyers.get(0);
+        assertThat(firstLawyer.getName()).isNotBlank();
+        assertThat(firstLawyer.getDistrict()).isNotBlank();
+        assertThat(firstLawyer.getCorporation()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("첫 페이지 노무사 정보 확인")
+    void t2() throws Exception {
+        lawyerCrawlerService.crawlMultiPages(1, 1);
+
+        List<Lawyer> result = lawyerRepository.findAll();
+        assertThat(result).isNotEmpty();
+
+        Lawyer targetLawyer = result.stream()
+                .filter(l -> l.getName().equals("조갑식"))
+                .findFirst()
+                .get();
+
+        assertThat(targetLawyer.getDistrict()).containsAnyOf("중구", "종로구", "서초구", "동대문구");
+        assertThat(targetLawyer.getCorporation()).isEqualTo("노무법인 케이에스");
+    }
+}


### PR DESCRIPTION
`feat/lawyer-crawling`

## 🔗 Issue 번호

- Close #41

## 🛠 작업 내역
해당 사이트에서 노무사 정보를 받아와, 지정해준 페이지만큼의 데이터를 엔티티로 저장하는 기능 구현.

- Jsoup 의존성 추가
- lawyer 관련 서비스, 레포지토리 추가
- 웹 페이지 크롤링해 lawyer 엔티티로 저장
- 테스트 코드 추가

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?