### PR TITLE
fix : 노무사, 센터 페이지 추가/ 홈 페이지 메뉴 수정 #182

### DIFF
--- a/frontend/src/api/center.ts
+++ b/frontend/src/api/center.ts
@@ -1,0 +1,82 @@
+import {
+  CenterSearchRequest,
+  CenterSearchResponse,
+  LawyerSearchRequest,
+  LawyerPageResponse,
+} from "../types/center";
+
+export class ApiError extends Error {
+  constructor(
+    public resultCode: string,
+    public msg: string
+  ) {
+    super(`${resultCode}: ${msg}`);
+    this.name = "ApiError";
+  }
+}
+
+/**
+ * 복지 센터 검색
+ * GET /api/v1/welfare/center/location
+ */
+export async function searchCenters(
+  req: CenterSearchRequest
+): Promise<CenterSearchResponse> {
+  const params = new URLSearchParams({
+    sido: req.sido,
+    signguNm: req.signguNm,
+  });
+
+  const response = await fetch(
+    `/api/v1/welfare/center/location?${params.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new ApiError(errorData.resultCode || "UNKNOWN", errorData.msg || "Unknown error");
+  }
+
+  return response.json();
+}
+
+/**
+ * 법률 상담소 검색
+ * GET /api/v1/welfare/center/location/lawyer
+ */
+export async function searchLawyers(
+  req: LawyerSearchRequest
+): Promise<LawyerPageResponse> {
+  const params = new URLSearchParams();
+  params.append("area1", req.area1);
+  if (req.area2) params.append("area2", req.area2);
+  if (req.page !== undefined) params.append("page", req.page.toString());
+  if (req.size !== undefined) params.append("size", req.size.toString());
+  if (req.sort) {
+    req.sort.forEach((s) => params.append("sort", s));
+  }
+
+  const response = await fetch(
+    `/api/v1/welfare/center/location/lawyer?${params.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new ApiError(errorData.resultCode || "UNKNOWN", errorData.msg || "Unknown error");
+  }
+
+  return response.json();
+}

--- a/frontend/src/app/join/page.tsx
+++ b/frontend/src/app/join/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { join, ApiError } from "@/api/member";
 import type { JoinRequest } from "@/types/member";
-import Header from "@/components/Header";
 
 export default function JoinPage() {
   const router = useRouter();
@@ -50,7 +49,6 @@ export default function JoinPage() {
 
   return (
     <div>
-      <Header />
       <main style={{ padding: "20px" }}>
         <h1>회원가입</h1>
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <Header />
+          <main>{children}</main>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { login, ApiError } from "@/api/member";
 import { useAuth } from "@/contexts/AuthContext";
 import type { LoginRequest } from "@/types/member";
-import Header from "@/components/Header";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -51,7 +50,6 @@ export default function LoginPage() {
 
   return (
     <div>
-      <Header />
       <main style={{ padding: "20px" }}>
         <h1>로그인</h1>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import Header from "@/components/Header";
 import PolicySearch from "@/components/PolicySearch";
 
 export default function HomePage() {
   return (
     <div>
-      <Header />
       <main style={{ padding: "20px" }}>
         <h1>정책 검색</h1>
         <PolicySearch />

--- a/frontend/src/app/welfare/center/page.tsx
+++ b/frontend/src/app/welfare/center/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { searchCenters } from "@/api/center";
+import { Center } from "@/types/center";
+
+export default function CenterSearchPage() {
+  const [sido, setSido] = useState("");
+  const [signguNm, setSignguNm] = useState("");
+  const [centers, setCenters] = useState<Center[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async () => {
+    if (!sido || !signguNm) {
+      alert("시/도와 시/군/구를 모두 입력해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await searchCenters({ sido, signguNm });
+      setCenters(response.centerList);
+    } catch (err: any) {
+      setError(err.message || "검색 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h1>복지 센터 검색</h1>
+      
+      <div style={{ marginBottom: "20px" }}>
+        <input
+          type="text"
+          placeholder="시/도 (예: 서울특별시)"
+          value={sido}
+          onChange={(e) => setSido(e.target.value)}
+          style={{ marginRight: "10px", padding: "5px" }}
+        />
+        <input
+          type="text"
+          placeholder="시/군/구 (예: 종로구)"
+          value={signguNm}
+          onChange={(e) => setSignguNm(e.target.value)}
+          style={{ marginRight: "10px", padding: "5px" }}
+        />
+        <button onClick={handleSearch} disabled={loading} style={{ padding: "5px 10px" }}>
+          {loading ? "검색 중..." : "검색"}
+        </button>
+      </div>
+
+      {error && <div style={{ color: "red", marginBottom: "20px" }}>{error}</div>}
+
+      <div>
+        <h2>검색 결과 ({centers.length}건)</h2>
+        {centers.length === 0 ? (
+          <p>검색 결과가 없습니다.</p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0 }}>
+            {centers.map((center) => (
+              <li key={center.id} style={{ border: "1px solid #ccc", margin: "10px 0", padding: "10px" }}>
+                <h3>{center.name}</h3>
+                <p><strong>주소:</strong> {center.address}</p>
+                <p><strong>연락처:</strong> {center.contact}</p>
+                <p><strong>운영자:</strong> {center.operator}</p>
+                <p><strong>유형:</strong> {center.corpType}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/welfare/lawyer/page.tsx
+++ b/frontend/src/app/welfare/lawyer/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { searchLawyers } from "@/api/center";
+import { LawyerResponse } from "@/types/center";
+
+export default function LawyerSearchPage() {
+  const [area1, setArea1] = useState("");
+  const [area2, setArea2] = useState("");
+  const [lawyers, setLawyers] = useState<LawyerResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async () => {
+    if (!area1) {
+      alert("시/도를 입력해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      // 페이지네이션은 일단 0페이지, 100개 사이즈로 고정하여 전체 조회 느낌으로 구현
+      const response = await searchLawyers({ area1, area2, page: 0, size: 100 });
+      setLawyers(response.content);
+    } catch (err: any) {
+      setError(err.message || "검색 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h1>법률 상담소 검색</h1>
+      
+      <div style={{ marginBottom: "20px" }}>
+        <input
+          type="text"
+          placeholder="시/도 (예: 서울특별시)"
+          value={area1}
+          onChange={(e) => setArea1(e.target.value)}
+          style={{ marginRight: "10px", padding: "5px" }}
+        />
+        <input
+          type="text"
+          placeholder="시/군/구 (선택)"
+          value={area2}
+          onChange={(e) => setArea2(e.target.value)}
+          style={{ marginRight: "10px", padding: "5px" }}
+        />
+        <button onClick={handleSearch} disabled={loading} style={{ padding: "5px 10px" }}>
+          {loading ? "검색 중..." : "검색"}
+        </button>
+      </div>
+
+      {error && <div style={{ color: "red", marginBottom: "20px" }}>{error}</div>}
+
+      <div>
+        <h2>검색 결과 ({lawyers.length}건)</h2>
+        {lawyers.length === 0 ? (
+          <p>검색 결과가 없습니다.</p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0 }}>
+            {lawyers.map((lawyer) => (
+              <li key={lawyer.id} style={{ border: "1px solid #ccc", margin: "10px 0", padding: "10px" }}>
+                <h3>{lawyer.name}</h3>
+                <p><strong>법인명:</strong> {lawyer.corporation}</p>
+                <p><strong>지역:</strong> {lawyer.districtArea1} {lawyer.districtArea2}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -33,7 +33,9 @@ export default function Header() {
       <span>|</span>
       <Link href="/estate">행복주택</Link>
       <span>|</span>
-      <span>시설찾기</span>
+      <Link href="/welfare/center">시설찾기</Link>
+      <span>|</span>
+      <Link href="/welfare/lawyer">노무사 찾기</Link>
       <span>|</span>
       {isLoading ? (
         <span>로딩중...</span>

--- a/frontend/src/types/center.ts
+++ b/frontend/src/types/center.ts
@@ -1,0 +1,46 @@
+import { Page } from './common';
+
+/**
+ * API: GET /api/v1/welfare/center/location
+ * Request Params: sido, signguNm
+ */
+export interface CenterSearchRequest {
+  sido: string;
+  signguNm: string;
+}
+
+export interface Center {
+  id: number;
+  location: string;
+  name: string;
+  address: string;
+  contact: string;
+  operator: string;
+  corpType: string;
+}
+
+export interface CenterSearchResponse {
+  centerList: Center[];
+}
+
+/**
+ * API: GET /api/v1/welfare/center/location/lawyer
+ * Request Params: LawyerReq + Pageable
+ */
+export interface LawyerSearchRequest {
+  area1: string; // 시/도
+  area2?: string; // 군/구
+  page?: number;
+  size?: number;
+  sort?: string[];
+}
+
+export interface LawyerResponse {
+  id: number;
+  name: string;
+  corporation: string;
+  districtArea1: string;
+  districtArea2: string;
+}
+
+export type LawyerPageResponse = Page<LawyerResponse>;

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,0 +1,28 @@
+export interface Page<T> {
+  content: T[];
+  pageable: {
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    offset: number;
+    pageNumber: number;
+    pageSize: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+  last: boolean;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  first: boolean;
+  numberOfElements: number;
+  empty: boolean;
+}


### PR DESCRIPTION
`feat/fontend-lawyer&center`
## 🔗 Issue 번호
- Close #182 

## 🛠 작업 내역

1. 메인페이지 시설찾기/노무사 누르면 시설찾기/노무사 페이지로 이동
2. 센터 찾기 기능을 프론트로 구현 - > 목록으로면 검색내역 보여주면됨
3. 노무사 찾기 기능 -> 목록으로
---
<img width="1152" height="294" alt="image (4)" src="https://github.com/user-attachments/assets/bea50c0d-5162-4a64-af75-ad44903c45fb" />
ㄴ 메인 페이지에 시설 찾기/ 노무사 페이지 구현


<img width="873" height="775" alt="image (5)" src="https://github.com/user-attachments/assets/c2ba8c04-4ee4-4a35-931e-4aa12ae5c9ca" />
ㄴ 센터 검색 페이지 구현

<img width="825" height="767" alt="image (6)" src="https://github.com/user-attachments/assets/bab45f10-6eb6-4737-b46e-b6267f4bbd53" />
ㄴ 노무사 검색 페이지 구현



## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?