### PR TITLE
fix: 소셜로그인하여 email이 null인 경우도 기존 email과 정상적으로 비교하도록 수정

### DIFF
--- a/backend/back/src/main/java/com/back/domain/member/member/service/MemberDetailService.java
+++ b/backend/back/src/main/java/com/back/domain/member/member/service/MemberDetailService.java
@@ -1,5 +1,7 @@
 package com.back.domain.member.member.service;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,8 +88,8 @@ public class MemberDetailService {
         String newRrnFront = (req.rrnFront() != null ? req.rrnFront() : member.getRrnFront());
         String newRrnBackFirst = (req.rrnBackFirst() != null ? req.rrnBackFirst() : member.getRrnBackFirst());
 
-        // 이메일이 변경되는 경우에만 중복 체크
-        if (!member.getEmail().equals(newEmail)) {
+        // 이메일이 변경되는 경우에만 중복 체크. 이메일이 null인 경우도 안전하게 비교
+        if (!Objects.equals(member.getEmail(), newEmail)) {
 
             // ACTIVE 회원 중에서만 중복 체크
             if (memberRepository.existsByEmailAndStatus(newEmail, Member.MemberStatus.ACTIVE)) {


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #205

## 🛠 작업 내역

-소셜로그인하여 email이 null인 경우도 기존 email과 정상적으로 비교하도록 수정

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?